### PR TITLE
Update uglify js package for make web demo

### DIFF
--- a/make/web/package.json
+++ b/make/web/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "devDependencies": {
     "node-sass": "^4.5.0",
-    "uglifyjs": "^2.4.10"
+    "uglify-js": "^3.4.9"
   }
 }


### PR DESCRIPTION
While watching the make video and running through the web tutorial, I ran into an error running the makefile. It was having an issue with uglifying the JavaScript.

The original package was set to uglifyjs. When I went to that folder, there was a message there indicating uglifyjs has been deprecated and you should use uglify-js instead. I have updated the package.json to reflect the new package. 

I ran the makefile and everything works as expected now. Thanks for the videos!